### PR TITLE
Add logging functionality in CoverageTool

### DIFF
--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -1286,8 +1286,7 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
                     permissionRequestType = PERMISSION_REQUEST_STORAGE_IMAGE_ICON;
                 } else {
                     CoverageTool.setFunc2Flag(17);
-                    throw new IllegalArgument
-                    Exception("Unknown ID type " + v.getId());
+                    throw new IllegalArgumentException("Unknown ID type " + v.getId());
                 }
 
                 PermissionUtils.requestStorageReadPermission(LoyaltyCardEditActivity.this, permissionRequestType);
@@ -1349,12 +1348,13 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
                         for (int i = 0; i < which; i++) {
                             callable = callables.next();
                         }
+                        CoverageTool.setFunc2Flag(28);
 
                         try {
-                            CoverageTool.setFunc2Flag(28);
+                            CoverageTool.setFunc2Flag(29);
                             callable.call();
                         } catch (Exception e) {
-                            CoverageTool.setFunc2Flag(29);
+                            CoverageTool.setFunc2Flag(30);
                             e.printStackTrace();
 
                             // Rethrow as NoSuchElementException
@@ -1363,7 +1363,7 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
                         }
                     })
                     .show();
-            CoverageTool.setFunc2Flag(30);       
+            CoverageTool.setFunc2Flag(31);//the last one        
         }
     }
 

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -92,7 +92,7 @@ import protect.card_locker.async.TaskHandler;
 import protect.card_locker.databinding.LayoutChipChoiceBinding;
 import protect.card_locker.databinding.LoyaltyCardEditActivityBinding;
 import protect.card_locker.viewmodels.LoyaltyCardEditActivityViewModel;
-import protect.card_locker.CoverageTool;
+import protect.card_locker.coverage.CoverageTool;
 
 public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements BarcodeImageWriterResultCallback, ColorPickerDialogListener {
     private static final String TAG = "Catima";

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -92,6 +92,7 @@ import protect.card_locker.async.TaskHandler;
 import protect.card_locker.databinding.LayoutChipChoiceBinding;
 import protect.card_locker.databinding.LoyaltyCardEditActivityBinding;
 import protect.card_locker.viewmodels.LoyaltyCardEditActivityViewModel;
+import protect.card_locker.CoverageTool;
 
 public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements BarcodeImageWriterResultCallback, ColorPickerDialogListener {
     private static final String TAG = "Catima";
@@ -1198,53 +1199,71 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
             ImageView targetView;
 
             if (v.getId() == R.id.frontImageHolder) {
+                CoverageTool.setFunc2Flag(0);
                 currentImage = viewModel.getLoyaltyCard().getImageFront(LoyaltyCardEditActivity.this);
                 imageLocationType = ImageLocationType.front;
                 targetView = cardImageFront;
             } else if (v.getId() == R.id.backImageHolder) {
+                CoverageTool.setFunc2Flag(1);
                 currentImage = viewModel.getLoyaltyCard().getImageBack(LoyaltyCardEditActivity.this);
                 imageLocationType = ImageLocationType.back;
                 targetView = cardImageBack;
             } else if (v.getId() == R.id.thumbnail) {
+                CoverageTool.setFunc2Flag(2);
                 currentImage = viewModel.getLoyaltyCard().getImageThumbnail(LoyaltyCardEditActivity.this);
                 imageLocationType = ImageLocationType.icon;
                 targetView = thumbnail;
             } else {
+                CoverageTool.setFunc2Flag(3);
                 throw new IllegalArgumentException("Invalid IMAGE ID " + v.getId());
             }
 
             LinkedHashMap<String, Callable<Void>> cardOptions = new LinkedHashMap<>();
             if (currentImage != null && v.getId() != R.id.thumbnail) {
+                CoverageTool.setFunc2Flag(4);
                 cardOptions.put(getString(R.string.removeImage), () -> {
                     setCardImage(imageLocationType, targetView, null, true);
                     return null;
                 });
             }
+            else
+                CoverageTool.setFunc2Flag(5);
+            
 
             if (v.getId() == R.id.thumbnail) {
+                CoverageTool.setFunc2Flag(6);
                 cardOptions.put(getString(R.string.selectColor), () -> {
                     ColorPickerDialog.Builder dialogBuilder = ColorPickerDialog.newBuilder();
 
                     if (viewModel.getLoyaltyCard().headerColor != null) {
+                        CoverageTool.setFunc2Flag(7);
                         dialogBuilder.setColor(viewModel.getLoyaltyCard().headerColor);
                     }
+                    else
+                        CoverageTool.setFunc2Flag(8);
 
                     ColorPickerDialog dialog = dialogBuilder.create();
                     dialog.show(getSupportFragmentManager(), "color-picker-dialog");
                     return null;
                 });
             }
+            else
+                CoverageTool.setFunc2Flag(9);
 
             cardOptions.put(getString(R.string.takePhoto), () -> {
                 int permissionRequestType;
 
                 if (v.getId() == R.id.frontImageHolder) {
+                    CoverageTool.setFunc2Flag(10);
                     permissionRequestType = PERMISSION_REQUEST_CAMERA_IMAGE_FRONT;
                 } else if (v.getId() == R.id.backImageHolder) {
+                    CoverageTool.setFunc2Flag(11);
                     permissionRequestType = PERMISSION_REQUEST_CAMERA_IMAGE_BACK;
                 } else if (v.getId() == R.id.thumbnail) {
+                    CoverageTool.setFunc2Flag(12);
                     permissionRequestType = PERMISSION_REQUEST_CAMERA_IMAGE_ICON;
                 } else {
+                    CoverageTool.setFunc2Flag(13);
                     throw new IllegalArgumentException("Unknown ID type " + v.getId());
                 }
 
@@ -1257,13 +1276,18 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
                 int permissionRequestType;
 
                 if (v.getId() == R.id.frontImageHolder) {
+                    CoverageTool.setFunc2Flag(14);
                     permissionRequestType = PERMISSION_REQUEST_STORAGE_IMAGE_FRONT;
                 } else if (v.getId() == R.id.backImageHolder) {
+                    CoverageTool.setFunc2Flag(15);
                     permissionRequestType = PERMISSION_REQUEST_STORAGE_IMAGE_BACK;
                 } else if (v.getId() == R.id.thumbnail) {
+                    CoverageTool.setFunc2Flag(16);
                     permissionRequestType = PERMISSION_REQUEST_STORAGE_IMAGE_ICON;
                 } else {
-                    throw new IllegalArgumentException("Unknown ID type " + v.getId());
+                    CoverageTool.setFunc2Flag(17);
+                    throw new IllegalArgument
+                    Exception("Unknown ID type " + v.getId());
                 }
 
                 PermissionUtils.requestStorageReadPermission(LoyaltyCardEditActivity.this, permissionRequestType);
@@ -1272,34 +1296,47 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
             });
 
             if (v.getId() == R.id.thumbnail) {
+                CoverageTool.setFunc2Flag(18);
                 Bitmap imageFront = viewModel.getLoyaltyCard().getImageFront(LoyaltyCardEditActivity.this);
                 if (imageFront != null) {
+                    CoverageTool.setFunc2Flag(19);
                     cardOptions.put(getString(R.string.useFrontImage), () -> {
                         setThumbnailImage(Utils.resizeBitmap(imageFront, Utils.BITMAP_SIZE_SMALL));
 
                         return null;
                     });
                 }
+                else
+                    CoverageTool.setFunc2Flag(20);
 
                 Bitmap imageBack = viewModel.getLoyaltyCard().getImageBack(LoyaltyCardEditActivity.this);
                 if (imageBack != null) {
+                    CoverageTool.setFunc2Flag(21);
                     cardOptions.put(getString(R.string.useBackImage), () -> {
                         setThumbnailImage(Utils.resizeBitmap(imageBack, Utils.BITMAP_SIZE_SMALL));
 
                         return null;
                     });
                 }
+                else
+                    CoverageTool.setFunc2Flag(22);
             }
+            else
+                CoverageTool.setFunc2Flag(23);
 
             int titleResource;
 
             if (v.getId() == R.id.frontImageHolder) {
+                CoverageTool.setFunc2Flag(24);
                 titleResource = R.string.setFrontImage;
             } else if (v.getId() == R.id.backImageHolder) {
+                CoverageTool.setFunc2Flag(25);
                 titleResource = R.string.setBackImage;
             } else if (v.getId() == R.id.thumbnail) {
+                CoverageTool.setFunc2Flag(26);
                 titleResource = R.string.setIcon;
             } else {
+                CoverageTool.setFunc2Flag(27);
                 throw new IllegalArgumentException("Unknown ID type " + v.getId());
             }
 
@@ -1314,8 +1351,10 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
                         }
 
                         try {
+                            CoverageTool.setFunc2Flag(28);
                             callable.call();
                         } catch (Exception e) {
+                            CoverageTool.setFunc2Flag(29);
                             e.printStackTrace();
 
                             // Rethrow as NoSuchElementException
@@ -1324,6 +1363,7 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
                         }
                     })
                     .show();
+            CoverageTool.setFunc2Flag(30);       
         }
     }
 

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -1347,8 +1347,9 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity implements 
 
                         for (int i = 0; i < which; i++) {
                             callable = callables.next();
-                        }
-                        CoverageTool.setFunc2Flag(28);
+                            if(i==0)
+                                CoverageTool.setFunc2Flag(28);
+                        }                      
 
                         try {
                             CoverageTool.setFunc2Flag(29);

--- a/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardViewActivity.java
@@ -72,6 +72,8 @@ import protect.card_locker.async.TaskHandler;
 import protect.card_locker.databinding.LoyaltyCardViewLayoutBinding;
 import protect.card_locker.preferences.Settings;
 
+import protect.card_locker.coverage.CoverageTool;
+
 public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements BarcodeImageWriterResultCallback {
     private LoyaltyCardViewLayoutBinding binding;
     private static final String TAG = "Catima";
@@ -643,6 +645,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
 
         Window window = getWindow();
         if (window != null) {
+            CoverageTool.setFunc1Flag(0);
             // Hide the keyboard if still shown (could be the case when returning from edit activity
             window.setSoftInputMode(
                     WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN
@@ -654,30 +657,51 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
             // '1' is the brightest. We attempt to maximize the brightness
             // to help barcode readers scan the barcode.
             if (settings.useMaxBrightnessDisplayingBarcode()) {
+                CoverageTool.setFunc1Flag(1);
                 attributes.screenBrightness = 1F;
+            }
+            else {
+                CoverageTool.setFunc1Flag(2);
             }
 
             if (settings.getKeepScreenOn()) {
+                CoverageTool.setFunc1Flag(3);
                 window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+            }
+            else {
+                CoverageTool.setFunc1Flag(4);
             }
 
             if (settings.getDisableLockscreenWhileViewingCard()) {
+                CoverageTool.setFunc1Flag(5);
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+                    CoverageTool.setFunc1Flag(6);
                     setShowWhenLocked(true);
                 } else {
+                    CoverageTool.setFunc1Flag(7);
                     showWhenLockedSdkLessThan27(window);
                 }
+            }
+            else {
+                CoverageTool.setFunc1Flag(8);
             }
 
             window.setAttributes(attributes);
         }
+        else {
+            CoverageTool.setFunc1Flag(9);
+        }
 
         loyaltyCard = DBHelper.getLoyaltyCard(this, database, loyaltyCardId);
         if (loyaltyCard == null) {
+            CoverageTool.setFunc1Flag(10);
             Log.w(TAG, "Could not lookup loyalty card " + loyaltyCardId);
             Toast.makeText(this, R.string.noCardExistsError, Toast.LENGTH_LONG).show();
             finish();
             return;
+        }
+        else {
+            CoverageTool.setFunc1Flag(11);
         }
 
         setTitle(loyaltyCard.store);
@@ -696,8 +720,12 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         // Display full text on click in case it doesn't fit in a single line
         binding.mainImageDescription.setOnClickListener(v -> {
             if (mainImageIndex != 0) {
+                CoverageTool.setFunc1Flag(12);
                 // Don't show cardId dialog, we're displaying something else
                 return;
+            }
+            else {
+                CoverageTool.setFunc1Flag(13);
             }
 
             TextView cardIdView = new TextView(LoyaltyCardViewActivity.this);
@@ -719,8 +747,12 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         });
         binding.mainImageDescription.setOnLongClickListener(view -> {
             if (mainImageIndex != 0) {
+                CoverageTool.setFunc1Flag(14);
                 // Don't copy to clipboard, we're showing something else
                 return false;
+            }
+            else {
+                CoverageTool.setFunc1Flag(15);
             }
 
             copyCardIdToClipboard();
@@ -744,6 +776,12 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         binding.fabEdit.setBackgroundTintList(ColorStateList.valueOf(complementaryColor));
         Drawable editButtonIcon = binding.fabEdit.getDrawable();
         editButtonIcon.mutate();
+        if (Utils.needsDarkForeground(complementaryColor)) { // For ternary operator below
+            CoverageTool.setFunc1Flag(16);
+        }
+        else {
+            CoverageTool.setFunc1Flag(17);
+        }
         editButtonIcon.setTint(Utils.needsDarkForeground(complementaryColor) ? Color.BLACK : Color.WHITE);
         binding.fabEdit.setImageDrawable(editButtonIcon);
 
@@ -761,29 +799,44 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
 
         boolean isBarcodeSupported;
         if (format != null && !format.isSupported()) {
+            CoverageTool.setFunc1Flag(18);
             isBarcodeSupported = false;
 
             Toast.makeText(this, getString(R.string.unsupportedBarcodeType), Toast.LENGTH_LONG).show();
         } else if (format == null) {
+            CoverageTool.setFunc1Flag(19);
             isBarcodeSupported = false;
         } else {
+            CoverageTool.setFunc1Flag(20);
             isBarcodeSupported = true;
         }
 
         imageTypes = new ArrayList<>();
 
         if (isBarcodeSupported) {
+            CoverageTool.setFunc1Flag(21);
             imageTypes.add(ImageType.BARCODE);
+        }
+        else {
+            CoverageTool.setFunc1Flag(22);
         }
 
         frontImageBitmap = loyaltyCard.getImageFront(this);
         if (frontImageBitmap != null) {
+            CoverageTool.setFunc1Flag(23);
             imageTypes.add(ImageType.IMAGE_FRONT);
+        }
+        else {
+            CoverageTool.setFunc1Flag(24);
         }
 
         backImageBitmap = loyaltyCard.getImageBack(this);
         if (backImageBitmap != null) {
+            CoverageTool.setFunc1Flag(25);
             imageTypes.add(ImageType.IMAGE_BACK);
+        }
+        else {
+            CoverageTool.setFunc1Flag(26);
         }
 
         setStateBasedOnImageTypes();
@@ -795,6 +848,7 @@ public class LoyaltyCardViewActivity extends CatimaAppCompatActivity implements 
         invalidateOptionsMenu();
 
         ShortcutHelper.updateShortcuts(this);
+        CoverageTool.setFunc1Flag(27); // Flag to signal that there are no more branches
     }
 
     private void setStateBasedOnImageTypes() {

--- a/app/src/main/java/protect/card_locker/coverage/CoverageTool.java
+++ b/app/src/main/java/protect/card_locker/coverage/CoverageTool.java
@@ -1,0 +1,68 @@
+package protect.card_locker.coverage;
+
+/**
+ * The CoverageTool class provides functionality to track which branches have been covered
+ * during the execution of specific functions in the application. Each function has associated
+ * boolean flags that indicate the coverage status for up to 100 possible branches.
+ */
+public class CoverageTool {
+
+    private static boolean[] func1flags = new boolean[100];
+    private static boolean[] func2flags = new boolean[100];
+    private static boolean[] func3flags = new boolean[100];
+    private static boolean[] func4flags = new boolean[100];
+    private static boolean[] func5flags = new boolean[100];
+
+    /**
+     * Sets the flag for the specified branch that was taken in function 1.
+     *
+     * @param index the index of the branch that has been taken. Must be less than 100.
+     */
+    public static void setFunc1Flag(int index) {
+        func1flags[index] = true;
+    }
+
+    /**
+     * Sets the flag for the specified branch that was taken in function 2.
+     *
+     * @param index the index of the branch that has been taken. Must be less than 100.
+     */
+    public static void setFunc2Flag(int index) {
+        func2flags[index] = true;
+    }
+
+    /**
+     * Sets the flag for the specified branch that was taken in function 3.
+     *
+     * @param index the index of the branch that has been taken. Must be less than 100.
+     */
+    public static void setFunc3Flag(int index) {
+        func3flags[index] = true;
+    }
+
+    /**
+     * Sets the flag for the specified branch that was taken in function 4.
+     *
+     * @param index the index of the branch that has been taken. Must be less than 100.
+     */
+    public static void setFunc4Flag(int index) {
+        func4flags[index] = true;
+    }
+
+    /**
+     * Sets the flag for the specified branch that was taken in function 5.
+     *
+     * @param index the index of the branch that has been taken. Must be less than 100.
+     */
+    public static void setFunc5Flag(int index) {
+        func5flags[index] = true;
+    }
+
+    /**
+     * Outputs coverage statistics for the tracked functions. This method calculates and
+     * prints the percentage of branch coverage for each each function.
+     */
+    public void outputCoverageStatistics() {
+        // TODO: implement the output of the coverage statistics
+    }
+}

--- a/app/src/main/java/protect/card_locker/importexport/CatimaImporter.java
+++ b/app/src/main/java/protect/card_locker/importexport/CatimaImporter.java
@@ -39,6 +39,8 @@ import protect.card_locker.LoyaltyCard;
 import protect.card_locker.Utils;
 import protect.card_locker.ZipUtils;
 
+import protect.card_locker.coverage.CoverageTool; 
+
 /**
  * Class for importing a database from CSV (Comma Separate Values)
  * formatted data.
@@ -399,7 +401,10 @@ public class CatimaImporter implements Importer {
 
         String store = CSVHelpers.extractString(DBHelper.LoyaltyCardDbIds.STORE, record, "");
         if (store.isEmpty()) {
+            CoverageTool.setFunc3Flag(0);
             throw new FormatException("No store listed, but is required");
+        } else {
+            CoverageTool.setFunc3Flag(1);
         }
 
         String note = CSVHelpers.extractString(DBHelper.LoyaltyCardDbIds.NOTE, record, "");
@@ -409,10 +414,14 @@ public class CatimaImporter implements Importer {
         try {
             validFromLong = CSVHelpers.extractLong(DBHelper.LoyaltyCardDbIds.VALID_FROM, record);
         } catch (FormatException ignored) {
+            CoverageTool.setFunc3Flag(2);
             validFromLong = null;
         }
         if (validFromLong != null) {
+            CoverageTool.setFunc3Flag(3);
             validFrom = new Date(validFromLong);
+        } else {
+            CoverageTool.setFunc3Flag(4);
         }
 
         Date expiry = null;
@@ -420,10 +429,14 @@ public class CatimaImporter implements Importer {
         try {
             expiryLong = CSVHelpers.extractLong(DBHelper.LoyaltyCardDbIds.EXPIRY, record);
         } catch (FormatException ignored) {
+            CoverageTool.setFunc3Flag(5);
             expiryLong = null;
         }
         if (expiryLong != null) {
+            CoverageTool.setFunc3Flag(6);
             expiry = new Date(expiryLong);
+        } else {
+            CoverageTool.setFunc3Flag(7);
         }
 
         // These fields did not exist in versions 1.8.1 and before
@@ -431,32 +444,49 @@ public class CatimaImporter implements Importer {
         BigDecimal balance = new BigDecimal("0");
         String balanceString = CSVHelpers.extractString(DBHelper.LoyaltyCardDbIds.BALANCE, record, null);
         if (balanceString != null) {
+            CoverageTool.setFunc3Flag(8);
             try {
                 balance = new BigDecimal(CSVHelpers.extractString(DBHelper.LoyaltyCardDbIds.BALANCE, record, null));
             } catch (NumberFormatException ignored) {
+                CoverageTool.setFunc3Flag(9);
+
             }
+        } else {
+            CoverageTool.setFunc3Flag(10);
         }
 
         Currency balanceType = null;
         String unparsedBalanceType = CSVHelpers.extractString(DBHelper.LoyaltyCardDbIds.BALANCE_TYPE, record, "");
         if (!unparsedBalanceType.isEmpty()) {
+            CoverageTool.setFunc3Flag(11);
             balanceType = Currency.getInstance(unparsedBalanceType);
+        } else {
+            CoverageTool.setFunc3Flag(12);
         }
 
         String cardId = CSVHelpers.extractString(DBHelper.LoyaltyCardDbIds.CARD_ID, record, "");
         if (cardId.isEmpty()) {
+            CoverageTool.setFunc3Flag(13);
             throw new FormatException("No card ID listed, but is required");
+        } else {
+            CoverageTool.setFunc3Flag(14);
         }
 
         String barcodeId = CSVHelpers.extractString(DBHelper.LoyaltyCardDbIds.BARCODE_ID, record, "");
         if (barcodeId.isEmpty()) {
+            CoverageTool.setFunc3Flag(15);
             barcodeId = null;
+        } else {
+            CoverageTool.setFunc3Flag(16);
         }
 
         CatimaBarcode barcodeType = null;
         String unparsedBarcodeType = CSVHelpers.extractString(DBHelper.LoyaltyCardDbIds.BARCODE_TYPE, record, "");
         if (!unparsedBarcodeType.isEmpty()) {
+            CoverageTool.setFunc3Flag(17);
             barcodeType = CatimaBarcode.fromName(unparsedBarcodeType);
+        } else {
+            CoverageTool.setFunc3Flag(18);
         }
 
         // Barcode encoding information is only supported since Catima 2.41.0, so old exports will lack this field
@@ -465,40 +495,59 @@ public class CatimaImporter implements Importer {
         Charset barcodeEncoding = StandardCharsets.ISO_8859_1;
         String unparsedBarcodeEncoding = CSVHelpers.extractString(DBHelper.LoyaltyCardDbIds.BARCODE_ENCODING, record, "");
         if (!unparsedBarcodeEncoding.isEmpty()) {
+            CoverageTool.setFunc3Flag(19);
             barcodeEncoding = Charset.forName(unparsedBarcodeEncoding);
+        } else {
+            CoverageTool.setFunc3Flag(20);
         }
 
         Integer headerColor = null;
         try {
             headerColor = CSVHelpers.extractInt(DBHelper.LoyaltyCardDbIds.HEADER_COLOR, record);
         } catch (FormatException ignored) {
+            CoverageTool.setFunc3Flag(21);
         }
 
         int starStatus = 0;
         try {
             starStatus = CSVHelpers.extractInt(DBHelper.LoyaltyCardDbIds.STAR_STATUS, record);
         } catch (FormatException _e) {
+            CoverageTool.setFunc3Flag(22);
             // This field did not exist in versions 0.28 and before
             // We catch this exception so we can still import old backups
         }
-        if (starStatus != 1) starStatus = 0;
+        if (starStatus != 1) {
+            CoverageTool.setFunc3Flag(23);
+            starStatus = 0;
+        } else {
+            CoverageTool.setFunc3Flag(24);
+        }
 
         int archiveStatus = 0;
         try {
             archiveStatus = CSVHelpers.extractInt(DBHelper.LoyaltyCardDbIds.ARCHIVE_STATUS, record);
         } catch (FormatException _e) {
+            CoverageTool.setFunc3Flag(25);
             // This field did not exist in versions 2.16.3 and before
             // We catch this exception so we can still import old backups
         }
-        if (archiveStatus != 1) archiveStatus = 0;
+        if (archiveStatus != 1) {
+            CoverageTool.setFunc3Flag(26);
+            archiveStatus = 0;
+        } else {
+            CoverageTool.setFunc3Flag(27);
+        }
 
         Long lastUsed = 0L;
         try {
             lastUsed = CSVHelpers.extractLong(DBHelper.LoyaltyCardDbIds.LAST_USED, record);
         } catch (FormatException _e) {
+            CoverageTool.setFunc3Flag(28);
             // This field did not exist in versions 2.5.0 and before
             // We catch this exception so we can still import old backups
         }
+
+        CoverageTool.setFunc3Flag(29);      // Flag to signal that there are no more branches
 
         return new LoyaltyCard(
                 id,


### PR DESCRIPTION
Adds logging functionality in the CoverageTool class
* Writes coverage report to **app/build/reports/manual-coverage/report.txt**

TODO: Add functionality for generating the report after all tests have been executed